### PR TITLE
コレクション検索の強化とデータ正規化（自動検索・クエリ同期／都道府県統一）

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,43 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+- Next.js (pages router) + TypeScript + Tailwind.
+- App entry: `pages/` (e.g., `pages/index.tsx`, `pages/create.tsx`).
+- UI components: `components/` (e.g., `components/samples/PersonaList.tsx`).
+- Sample data/content: `samples/` (e.g., `samples/personas-list.json`, `samples/personas/<id>/{profile.md,prompt.md}`).
+- Utilities & types: `utils/`, `types/`.
+- Static assets: `public/`. Build outputs: `.next/`, `out/`.
+
+## Build, Test, and Development Commands
+- `npm run dev` — Start local dev server on `http://localhost:3000`.
+- `npm run build` — Production build (typecheck + Next build).
+- `npm start` — Serve the production build.
+- `npm run export` — Static export to `out/`.
+- `npm run lint` — ESLint (Next config).
+- `npm test` — Basic repository checks in `scripts/test-basic-functionality.js`.
+
+## Coding Style & Naming Conventions
+- TypeScript strictness preferred; keep props/interfaces explicit.
+- ESLint (Next) + Tailwind utility-first classes. No Prettier in repo—match existing style.
+- File names: React components in `PascalCase.tsx` (e.g., `PersonaList.tsx`), pages in `kebab-case.tsx` or route folders.
+- Routes: keep under `pages/` with clear, shallow paths (e.g., `/create`, `/samples/personas/[id]`).
+
+## Testing Guidelines
+- CI-style checks: `npm test` and `npm run build` should pass locally before pushing.
+- The test script validates file presence, form data sections, prompt generator strings, clipboard fallback, and build.
+- Add new tests to `scripts/` or extend the existing script when modifying critical flows.
+
+## Commit & Pull Request Guidelines
+- Commits: imperative, concise, scoped (e.g., `Add …`, `Fix …`, `Refactor …`).
+- PRs: 日本語で作成してください。要約・背景・変更範囲を明記し、関連Issueのリンク、`samples/`配下のスキーマ/コンテンツ変更があれば記載。
+- UI changes: attach before/after screenshots or GIFs; list impacted routes (e.g., `/`, `/create`).
+- Ensure `npm run lint`, `npm test`, and `npm run build` succeed before requesting review.
+
+## Security & Configuration Tips
+- This app is static/SSG focused; avoid secrets in the repo or client code.
+- Do not commit tokens or private data to `samples/`. Treat added content as public.
+
+## Agent-Specific Instructions
+- Keep changes minimal and focused; avoid unrelated refactors.
+- Respect existing structure and copy; update docs when moving files/routes.
+- When adding content, follow `samples/personas/<id>/profile.md` and `prompt.md` layout.

--- a/components/samples/PersonaList.tsx
+++ b/components/samples/PersonaList.tsx
@@ -1,16 +1,8 @@
-import React from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
+import { useRouter } from 'next/router';
 import { User, Briefcase, MapPin, Tag, ArrowRight, Sparkles } from 'lucide-react';
-
-interface Persona {
-  id: string;
-  name: string;
-  age: number;
-  occupation: string;
-  description: string;
-  image: string;
-  tags: string[];
-}
+import { Persona, matchesGender, locationMatches, containsText } from '@/types/persona';
 
 interface PersonaCardProps {
   persona: Persona;
@@ -100,6 +92,111 @@ interface PersonaListProps {
 }
 
 const PersonaList: React.FC<PersonaListProps> = ({ personas }) => {
+  const router = useRouter();
+  const [hydrated, setHydrated] = useState(false);
+  // Option lists
+  const occupationCategoryOptions = useMemo(() => {
+    const s = new Set<string>();
+    personas.forEach(p => p.occupationCategory && s.add(p.occupationCategory));
+    return Array.from(s);
+  }, [personas]);
+  const occupationOptions = useMemo(() => {
+    const s = new Set<string>();
+    personas.forEach(p => p.occupation && s.add(p.occupation));
+    return Array.from(s);
+  }, [personas]);
+  const birthplaceOptions = useMemo(() => {
+    const s = new Set<string>();
+    personas.forEach(p => p.birthplace?.prefecture && s.add(p.birthplace.prefecture));
+    return Array.from(s);
+  }, [personas]);
+  const residenceOptions = useMemo(() => {
+    const s = new Set<string>();
+    personas.forEach(p => p.residence?.prefecture && s.add(p.residence.prefecture));
+    return Array.from(s);
+  }, [personas]);
+
+  // Filters (selection-based)
+  const [gender, setGender] = useState<'all' | '女性' | '男性' | 'その他'>('all');
+  const [ageMin, setAgeMin] = useState<string>('');
+  const [ageMax, setAgeMax] = useState<string>('');
+  const [occupationCategory, setOccupationCategory] = useState<string>('');
+  const [occupation, setOccupation] = useState<string>('');
+  const [birthplace, setBirthplace] = useState<string>('');
+  const [residence, setResidence] = useState<string>('');
+  const [keyword, setKeyword] = useState<string>('');
+
+  const resetFilters = () => {
+    setGender('all');
+    setAgeMin('');
+    setAgeMax('');
+    setOccupationCategory('');
+    setOccupation('');
+    setBirthplace('');
+    setResidence('');
+    setKeyword('');
+    router.replace({ pathname: '/samples' }, undefined, { shallow: true });
+  };
+
+  // Load from query
+  useEffect(() => {
+    const q = router.query;
+    if (!q) return;
+    setGender((q.gender as any) || 'all');
+    setAgeMin((q.ageMin as string) || '');
+    setAgeMax((q.ageMax as string) || '');
+    setOccupationCategory((q.occupationCategory as string) || '');
+    setOccupation((q.occupation as string) || '');
+    setBirthplace((q.birthplace as string) || '');
+    setResidence((q.residence as string) || '');
+    setKeyword((q.q as string) || '');
+    // 状態反映後に同期を有効化（初期クエリを上書きしない）
+    setTimeout(() => setHydrated(true), 0);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [router.isReady]);
+
+  // Sync query when filters change (auto-search)
+  useEffect(() => {
+    if (!hydrated) return;
+    const query: Record<string, any> = {};
+    if (gender !== 'all') query.gender = gender;
+    if (ageMin) query.ageMin = ageMin;
+    if (ageMax) query.ageMax = ageMax;
+    if (occupationCategory) query.occupationCategory = occupationCategory;
+    if (occupation) query.occupation = occupation;
+    if (birthplace) query.birthplace = birthplace;
+    if (residence) query.residence = residence;
+    if (keyword) query.q = keyword;
+    router.replace({ pathname: '/samples', query }, undefined, { shallow: true });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [gender, ageMin, ageMax, occupationCategory, occupation, birthplace, residence, keyword, hydrated]);
+
+  const filtered = useMemo(() => {
+    return personas.filter((p) => {
+      if (gender !== 'all' && !matchesGender(p, gender as any)) return false;
+
+      const min = ageMin ? parseInt(ageMin, 10) : undefined;
+      const max = ageMax ? parseInt(ageMax, 10) : undefined;
+      if (min !== undefined && p.age < min) return false;
+      if (max !== undefined && p.age > max) return false;
+
+      if (occupationCategory && p.occupationCategory !== occupationCategory) return false;
+      if (occupation && p.occupation !== occupation) return false;
+
+
+      if (birthplace && p.birthplace?.prefecture !== birthplace) return false;
+      if (residence && p.residence?.prefecture !== residence) return false;
+
+      if (keyword) {
+        const q = keyword.toLowerCase();
+        const hit = containsText(p.name, q) || containsText(p.description, q) || containsText(p.occupation, q) || (p.tags || []).some(t => t.toLowerCase().includes(q));
+        if (!hit) return false;
+      }
+
+      return true;
+    });
+  }, [personas, gender, ageMin, ageMax, occupationCategory, occupation, birthplace, residence, keyword]);
+
   return (
     <div className="min-h-screen">
       {/* ヘッダー */}
@@ -172,39 +269,98 @@ const PersonaList: React.FC<PersonaListProps> = ({ personas }) => {
         </div>
       </section>
 
+      {/* フィルター */}
+      <section className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
+        <div className="card p-4">
+          <div className="grid md:grid-cols-3 lg:grid-cols-6 gap-3 items-end">
+            <div>
+              <label className="text-xs text-gray-600">性別</label>
+              <select className="mt-1 form-input" value={gender} onChange={(e) => setGender(e.target.value as any)}>
+                <option value="all">すべて</option>
+                <option value="女性">女性</option>
+                <option value="男性">男性</option>
+                <option value="その他">その他</option>
+              </select>
+            </div>
+            <div>
+              <label className="text-xs text-gray-600">年齢 最小</label>
+              <input type="number" inputMode="numeric" className="mt-1 form-input" placeholder="min" value={ageMin} onChange={(e) => setAgeMin(e.target.value)} />
+            </div>
+            <div>
+              <label className="text-xs text-gray-600">年齢 最大</label>
+              <input type="number" inputMode="numeric" className="mt-1 form-input" placeholder="max" value={ageMax} onChange={(e) => setAgeMax(e.target.value)} />
+            </div>
+            <div>
+              <label className="text-xs text-gray-600">職業カテゴリ</label>
+              <select className="mt-1 form-input" value={occupationCategory} onChange={(e) => setOccupationCategory(e.target.value)}>
+                <option value="">すべて</option>
+                {occupationCategoryOptions.map(opt => (
+                  <option key={opt} value={opt}>{opt}</option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <label className="text-xs text-gray-600">職業（詳細）</label>
+              <select className="mt-1 form-input" value={occupation} onChange={(e) => setOccupation(e.target.value)}>
+                <option value="">すべて</option>
+                {occupationOptions.map(opt => (
+                  <option key={opt} value={opt}>{opt}</option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <label className="text-xs text-gray-600">キーワード</label>
+              <input type="text" className="mt-1 form-input" placeholder="自由検索（名前・説明・タグなど）" value={keyword} onChange={(e) => setKeyword(e.target.value)} />
+            </div>
+          </div>
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-3 mt-3">
+            <div>
+              <label className="text-xs text-gray-600">出身地（都道府県）</label>
+              <select className="mt-1 form-input" value={birthplace} onChange={(e) => setBirthplace(e.target.value)}>
+                <option value="">すべて</option>
+                {birthplaceOptions.map(opt => (
+                  <option key={opt} value={opt}>{opt}</option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <label className="text-xs text-gray-600">在住地（都道府県）</label>
+              <select className="mt-1 form-input" value={residence} onChange={(e) => setResidence(e.target.value)}>
+                <option value="">すべて</option>
+                {residenceOptions.map(opt => (
+                  <option key={opt} value={opt}>{opt}</option>
+                ))}
+              </select>
+            </div>
+            {/* 性格・特徴の選択は未整備のため一旦未実装 */}
+            <div className="flex gap-2 md:col-span-2 lg:col-span-4 justify-between items-center">
+              <span className="text-xs text-gray-500">条件は変更と同時に適用されます</span>
+              <button className="btn-secondary h-10 px-3" onClick={resetFilters}>クリア</button>
+            </div>
+          </div>
+        </div>
+      </section>
+
       {/* ペルソナグリッド */}
       <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
-        {personas.length === 0 ? (
+        {filtered.length === 0 ? (
           <div className="text-center py-12">
             <div className="w-24 h-24 bg-gray-100 rounded-full flex items-center justify-center mx-auto mb-4">
               <User className="w-12 h-12 text-gray-400" />
             </div>
             <p className="text-gray-600 text-lg">
-              コンテキストが見つかりませんでした
+              条件に一致するコンテキストが見つかりませんでした
             </p>
           </div>
         ) : (
           <>
             <div className="flex justify-between items-center mb-8">
-              <h3 className="text-xl font-bold text-gray-900">全{personas.length}件のコンテキスト</h3>
-              <div className="flex gap-2">
-                <button className="tag-category">
-                  🎨 全て
-                </button>
-                <button className="tag">
-                  👨‍💼 ビジネス
-                </button>
-                <button className="tag">
-                  🎓 教育
-                </button>
-                <button className="tag">
-                  💻 IT
-                </button>
-              </div>
+              <h3 className="text-xl font-bold text-gray-900">該当 {filtered.length} 件のコンテキスト</h3>
+              <div className="text-sm text-gray-600">全 {personas.length} 件からフィルタ</div>
             </div>
             
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-              {personas.map((persona) => (
+              {filtered.map((persona) => (
                 <PersonaCard key={persona.id} persona={persona} />
               ))}
             </div>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,19 +1,11 @@
 import React from 'react';
 import { GetStaticProps } from 'next';
 import Head from 'next/head';
-import PersonaList from '../components/samples/PersonaList';
+import Link from 'next/link';
+import { ArrowRight, Sparkles, User } from 'lucide-react';
 import fs from 'fs';
 import path from 'path';
-
-interface Persona {
-  id: string;
-  name: string;
-  age: number;
-  occupation: string;
-  description: string;
-  image: string;
-  tags: string[];
-}
+import { Persona } from '@/types/persona';
 
 interface HomeProps {
   personas: Persona[];
@@ -23,12 +15,182 @@ export default function Home({ personas }: HomeProps) {
   return (
     <>
       <Head>
-        <title>Context Collection | ユーザーインタビュー用コンテキスト集</title>
-        <meta name="description" content="ユーザーインタビューがすぐに始められる高品質なコンテキストコレクション。職種・状況別に整理されたプロファイルとプロンプトを提供。" />
+        <title>Context Collection | ユーザーインタビューのための文脈を整える</title>
+        <meta name="description" content="ユーザーインタビューがすぐに始められる高品質なコンテキスト。職種・状況別のプロファイルとプロンプトを提供し、作成も簡単。" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
       </Head>
       <main className="min-h-screen bg-gray-50">
-        <PersonaList personas={personas} />
+        {/* Header */}
+        <header className="bg-white/80 backdrop-blur-lg shadow-soft border-b border-gray-100 sticky top-0 z-40">
+          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div className="flex justify-between items-center py-4">
+              <div className="flex items-center space-x-3">
+                <Link href="/" className="flex items-center space-x-3">
+                  <div className="w-10 h-10 bg-gradient-to-br from-mint-400 to-mint-500 rounded-xl flex items-center justify-center shadow-soft animate-float">
+                    <Sparkles className="w-6 h-6 text-white" />
+                  </div>
+                  <div>
+                    <h1 className="text-xl font-bold bg-gradient-to-r from-mint-600 to-peach-600 bg-clip-text text-transparent">Context Collection</h1>
+                    <p className="text-xs text-gray-500">ユーザーインタビュー用コンテキスト集</p>
+                  </div>
+                </Link>
+              </div>
+              <nav className="hidden md:flex items-center space-x-1">
+                <button className="nav-item nav-item-active">🏠 ホーム</button>
+                <Link href="/samples" className="nav-item">🗂 コレクション</Link>
+                <Link href="/create" className="nav-item">✍️ 作成</Link>
+                <button className="nav-item">⭐ お気に入り</button>
+              </nav>
+              <div className="flex items-center space-x-3">
+                <span className="badge badge-new">✨ NEW</span>
+              </div>
+            </div>
+          </div>
+        </header>
+        {/* Hero */}
+        <section className="relative overflow-hidden bg-gradient-to-br from-mint-50 via-peach-50 to-lavender-50">
+          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+            <div className="flex items-start gap-3 mb-6">
+              <div className="w-10 h-10 bg-gradient-to-br from-mint-400 to-mint-500 rounded-xl flex items-center justify-center shadow-soft">
+                <Sparkles className="w-6 h-6 text-white" />
+              </div>
+              <div>
+                <h1 className="text-3xl md:text-4xl font-bold text-gray-900">ユーザーインタビュー用コンテキスト</h1>
+                <p className="text-gray-600 mt-2">対象ユーザー像・状況・制約・口調まで。すぐに使えるプロンプト付き。</p>
+              </div>
+            </div>
+            <div className="flex flex-wrap gap-3">
+              <Link href="/create" className="btn-primary inline-flex items-center px-4 py-2 rounded-lg">
+                <span>✍️ コンテキストを作成する</span>
+              </Link>
+              <Link href="/samples" className="nav-item inline-flex items-center">
+                <span>🗂 コレクションを見る</span>
+                <ArrowRight className="w-4 h-4 ml-1" />
+              </Link>
+            </div>
+          </div>
+        </section>
+
+        {/* Teaser collection (top 3) */}
+        <section className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+          <div className="flex items-center justify-between mb-6">
+            <h2 className="text-xl font-bold text-gray-900">おすすめコレクション（抜粋）</h2>
+            <Link href="/samples" className="text-blue-600 hover:text-blue-800 inline-flex items-center text-sm">
+              すべて見る <ArrowRight className="w-4 h-4 ml-1" />
+            </Link>
+          </div>
+          {personas.length === 0 ? (
+            <div className="text-center py-12">
+              <div className="w-24 h-24 bg-gray-100 rounded-full flex items-center justify-center mx-auto mb-4">
+                <User className="w-12 h-12 text-gray-400" />
+              </div>
+              <p className="text-gray-600 text-lg">コンテキストが見つかりませんでした</p>
+            </div>
+          ) : (
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+              {personas.slice(0, 3).map((p) => (
+                <Link key={p.id} href={`/samples/personas/${p.id}`} className="card-persona group">
+                  <div className="relative h-40 -mx-6 -mt-6 mb-4 bg-gradient-to-br from-mint-100 via-peach-100 to-lavender-100 flex items-center justify-center overflow-hidden rounded-t-2xl">
+                    {p.image ? (
+                      // eslint-disable-next-line @next/next/no-img-element
+                      <img src={p.image} alt={p.name} className="w-full h-full object-cover" />
+                    ) : (
+                      <div className="w-20 h-20 bg-white rounded-full flex items-center justify-center shadow-lg">
+                        <User className="w-10 h-10 text-mint-400" />
+                      </div>
+                    )}
+                  </div>
+                  <div className="space-y-2">
+                    <h3 className="text-lg font-bold text-gray-900">{p.name}</h3>
+                    <p className="text-gray-600 text-sm line-clamp-2">{p.description}</p>
+                    <div className="flex flex-wrap gap-2 pt-2">
+                      {p.tags.slice(0, 2).map((t, i) => (
+                        <span key={i} className="inline-flex items-center px-2 py-0.5 rounded-lg text-xs font-medium bg-gray-100 text-gray-700">{t}</span>
+                      ))}
+                      {p.tags.length > 2 && (
+                        <span className="inline-flex items-center px-2 py-0.5 rounded-lg text-xs font-medium bg-gray-50 text-gray-500">+{p.tags.length - 2}</span>
+                      )}
+                    </div>
+                  </div>
+                </Link>
+              ))}
+            </div>
+          )}
+        </section>
+
+        {/* Create feature brief */}
+        <section className="bg-white border-t border-gray-100">
+          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+            <div className="grid md:grid-cols-3 gap-6 items-start">
+              <div className="md:col-span-2">
+                <h2 className="text-xl font-bold text-gray-900 mb-2">コンテキスト生成で、インタビューを効率化</h2>
+                <p className="text-gray-600 mb-4">対象ユーザー像、状況、制約、口調、出力形式を整えた高品質なプロンプトを簡単に生成できます。</p>
+                <ul className="text-sm text-gray-700 space-y-2">
+                  <li>• 対象ユーザーと状況の定義</li>
+                  <li>• 口調・出力形式の統一</li>
+                  <li>• 制約/前提条件の明示</li>
+                </ul>
+              </div>
+              <div className="flex md:justify-end items-start">
+                <Link href="/create" className="btn-primary inline-flex items-center h-10 px-4">
+                  ✍️ コンテキストを作成する
+                </Link>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* Footer */}
+        <footer className="bg-white border-t border-gray-100 mt-16">
+          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+            <div className="grid md:grid-cols-4 gap-8">
+              <div className="md:col-span-2">
+                <div className="flex items-center space-x-2 mb-4">
+                  <div className="w-8 h-8 bg-gradient-to-br from-mint-400 to-mint-500 rounded-lg flex items-center justify-center">
+                    <Sparkles className="w-5 h-5 text-white" />
+                  </div>
+                  <span className="font-bold text-lg">Context Collection</span>
+                </div>
+                <p className="text-sm text-gray-600">
+                  ユーザーインタビューをもっと楽しく、効果的に。
+                  調査と検証の質を上げるためのコンテキストを整えましょう。
+                </p>
+              </div>
+
+              <div>
+                <h3 className="text-sm font-bold text-gray-900 mb-4">特徴</h3>
+                <ul className="space-y-2 text-sm text-gray-600">
+                  <li>• 簡単3ステップ作成</li>
+                  <li>• 共有しやすい構成</li>
+                  <li>• テンプレート継続改善</li>
+                </ul>
+              </div>
+
+              <div>
+                <h3 className="text-sm font-bold text-gray-900 mb-4">対応AI</h3>
+                <ul className="space-y-2 text-sm text-gray-600">
+                  <li>• ChatGPT</li>
+                  <li>• Claude</li>
+                  <li>• Gemini</li>
+                  <li>• その他主要AI</li>
+                </ul>
+              </div>
+            </div>
+
+            <div className="mt-8 pt-8 border-t border-gray-200">
+              <div className="flex flex-col md:flex-row justify-between items-center">
+                <p className="text-sm text-gray-500 mb-4 md:mb-0">
+                  © 2024 Context Collection. Made with 💚 for UX/Research.
+                </p>
+                <div className="flex space-x-6">
+                  <a href="#" className="text-sm text-gray-500 hover:text-mint-600 transition-colors">プライバシー</a>
+                  <a href="#" className="text-sm text-gray-500 hover:text-mint-600 transition-colors">利用規約</a>
+                  <a href="#" className="text-sm text-gray-500 hover:text-mint-600 transition-colors">お問い合わせ</a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </footer>
       </main>
     </>
   );

--- a/pages/samples/index.tsx
+++ b/pages/samples/index.tsx
@@ -4,16 +4,7 @@ import Head from 'next/head';
 import PersonaList from '../../components/samples/PersonaList';
 import fs from 'fs';
 import path from 'path';
-
-interface Persona {
-  id: string;
-  name: string;
-  age: number;
-  occupation: string;
-  description: string;
-  image: string;
-  tags: string[];
-}
+import { Persona } from '@/types/persona';
 
 interface SamplesPageProps {
   personas: Persona[];

--- a/pages/samples/personas/[id].tsx
+++ b/pages/samples/personas/[id].tsx
@@ -5,16 +5,7 @@ import Link from 'next/link';
 import { ArrowLeft, User, Briefcase, MapPin, Calendar, Tag, Download, Eye } from 'lucide-react';
 import fs from 'fs';
 import path from 'path';
-
-interface Persona {
-  id: string;
-  name: string;
-  age: number;
-  occupation: string;
-  description: string;
-  image: string;
-  tags: string[];
-}
+import { Persona } from '@/types/persona';
 
 interface PersonaDetailPageProps {
   persona: Persona;

--- a/pages/samples/personas/[id]/prompt.tsx
+++ b/pages/samples/personas/[id]/prompt.tsx
@@ -5,16 +5,7 @@ import Link from 'next/link';
 import { ArrowLeft, Copy, Download, Check, User } from 'lucide-react';
 import fs from 'fs';
 import path from 'path';
-
-interface Persona {
-  id: string;
-  name: string;
-  age: number;
-  occupation: string;
-  description: string;
-  image: string;
-  tags: string[];
-}
+import { Persona } from '@/types/persona';
 
 interface PromptPageProps {
   persona: Persona;

--- a/samples/personas-list.json
+++ b/samples/personas-list.json
@@ -6,7 +6,21 @@
     "occupation": "ITベンチャー企業 プロダクトマネージャー",
     "description": "静岡出身、東京で働くキャリア志向の女性。ヨガと読書が趣味で、自分らしい働き方を追求中。",
     "image": "/images/personas/tanaka-sakiko.png",
-    "tags": ["IT", "女性", "キャリア", "20代", "東京"]
+    "tags": [
+      "IT",
+      "女性",
+      "キャリア",
+      "20代",
+      "東京"
+    ],
+    "gender": "女性",
+    "birthplace": {
+      "prefecture": "静岡県"
+    },
+    "residence": {
+      "prefecture": "東京都"
+    },
+    "occupationCategory": "IT"
   },
   {
     "id": "yamada-taro",
@@ -15,7 +29,19 @@
     "occupation": "フリーランスWebエンジニア",
     "description": "大阪出身の関西弁エンジニア。妻と2歳の息子がいて、ワークライフバランスを重視。ゲームとアニメが大好き。",
     "image": "/images/personas/yamada-taro.png",
-    "tags": ["エンジニア", "男性", "関西弁", "フリーランス", "30代", "家族"]
+    "tags": [
+      "エンジニア",
+      "男性",
+      "関西弁",
+      "フリーランス",
+      "30代",
+      "家族"
+    ],
+    "gender": "男性",
+    "birthplace": {
+      "prefecture": "大阪府"
+    },
+    "occupationCategory": "IT"
   },
   {
     "id": "sato-kanon",
@@ -24,7 +50,20 @@
     "occupation": "早稲田大学文学部2年生",
     "description": "横浜出身の大学生。文学とカフェ巡りが好きで、K-POPと韓国ドラマにも夢中。将来は出版業界を志望。",
     "image": "/images/personas/sato-kanon.png",
-    "tags": ["大学生", "女性", "文学", "20代", "東京", "K-POP"]
+    "tags": [
+      "大学生",
+      "女性",
+      "文学",
+      "20代",
+      "東京",
+      "K-POP"
+    ],
+    "gender": "女性",
+    "birthplace": {
+      "prefecture": "神奈川県",
+      "city": "横浜"
+    },
+    "occupationCategory": "教育"
   },
   {
     "id": "suzuki-koji",
@@ -33,7 +72,19 @@
     "occupation": "中堅メーカー営業部長",
     "description": "茨城出身の営業管理職。妻と高校生・中学生の息子2人の父。ゴルフと読書が趣味で、部下思いのリーダー。",
     "image": "/images/personas/suzuki-koji.png",
-    "tags": ["営業", "男性", "管理職", "40代", "父親", "ゴルフ"]
+    "tags": [
+      "営業",
+      "男性",
+      "管理職",
+      "40代",
+      "父親",
+      "ゴルフ"
+    ],
+    "gender": "男性",
+    "birthplace": {
+      "prefecture": "茨城県"
+    },
+    "occupationCategory": "営業"
   },
   {
     "id": "takahashi-akari",
@@ -42,7 +93,21 @@
     "occupation": "美容部員 / SNSインフルエンサー",
     "description": "埼玉出身、渋谷区在住。百貨店勤務の美容部員で副業でSNS活動。TikTokとInstagramで合計10万フォロワー。",
     "image": "/images/personas/takahashi-akari.png",
-    "tags": ["美容", "女性", "インフルエンサー", "20代", "東京"]
+    "tags": [
+      "美容",
+      "女性",
+      "インフルエンサー",
+      "20代",
+      "東京"
+    ],
+    "gender": "女性",
+    "birthplace": {
+      "prefecture": "埼玉県"
+    },
+    "residence": {
+      "prefecture": "東京都",
+      "city": "渋谷区"
+    }
   },
   {
     "id": "ito-misaki",
@@ -51,7 +116,21 @@
     "occupation": "公立小学校教諭",
     "description": "北海道出身、千葉県在住。5年生担任の小学校教師。夫と2人の子供の母親。インクルーシブ教育に情熱を注ぐ。",
     "image": "/images/personas/ito-misaki.png",
-    "tags": ["教師", "女性", "母親", "40代", "千葉"]
+    "tags": [
+      "教師",
+      "女性",
+      "母親",
+      "40代",
+      "千葉"
+    ],
+    "gender": "女性",
+    "birthplace": {
+      "prefecture": "北海道"
+    },
+    "residence": {
+      "prefecture": "千葉県"
+    },
+    "occupationCategory": "教育"
   },
   {
     "id": "matsumoto-rina",
@@ -60,7 +139,22 @@
     "occupation": "UXデザイナー",
     "description": "神戸出身、大阪在住。スタートアップ企業のUXデザイナー。彼氏と同棲中で、アートとデザインを愛する。",
     "image": "/images/personas/matsumoto-rina.png",
-    "tags": ["デザイナー", "女性", "スタートアップ", "20代", "大阪"]
+    "tags": [
+      "デザイナー",
+      "女性",
+      "スタートアップ",
+      "20代",
+      "大阪"
+    ],
+    "gender": "女性",
+    "birthplace": {
+      "prefecture": "兵庫県",
+      "city": "神戸"
+    },
+    "residence": {
+      "prefecture": "大阪府"
+    },
+    "occupationCategory": "デザイン"
   },
   {
     "id": "nakamura-yui",
@@ -69,7 +163,21 @@
     "occupation": "フリーランスイラストレーター",
     "description": "福岡出身、鎌倉在住。夫と猫2匹と暮らすイラストレーター。絵本がベストセラーに。自然と創作を愛する。",
     "image": "/images/personas/nakamura-yui.png",
-    "tags": ["イラストレーター", "女性", "フリーランス", "30代", "鎌倉"]
+    "tags": [
+      "イラストレーター",
+      "女性",
+      "フリーランス",
+      "30代",
+      "鎌倉"
+    ],
+    "gender": "女性",
+    "birthplace": {
+      "prefecture": "福岡県"
+    },
+    "residence": {
+      "prefecture": "神奈川県",
+      "city": "鎌倉"
+    }
   },
   {
     "id": "watanabe-haruka",
@@ -78,7 +186,19 @@
     "occupation": "製菓専門学校生 / カフェ店員",
     "description": "名古屋在住の製菓専門学校生。パティシエを目指して修行中。祖母が和菓子職人で、お菓子作りが人生。",
     "image": "/images/personas/watanabe-haruka.png",
-    "tags": ["学生", "女性", "パティシエ", "10代", "名古屋"]
+    "tags": [
+      "学生",
+      "女性",
+      "パティシエ",
+      "10代",
+      "名古屋"
+    ],
+    "gender": "女性",
+    "residence": {
+      "prefecture": "愛知県",
+      "city": "名古屋"
+    },
+    "occupationCategory": "教育"
   },
   {
     "id": "kobayashi-chinatsu",
@@ -87,7 +207,18 @@
     "occupation": "大学准教授 / 作家",
     "description": "京都在住の文学研究者。源氏物語の専門家で、小説も執筆。独身で学問と創作に生きる。",
     "image": "/images/personas/kobayashi-chinatsu.png",
-    "tags": ["教授", "女性", "作家", "30代", "京都"]
+    "tags": [
+      "教授",
+      "女性",
+      "作家",
+      "30代",
+      "京都"
+    ],
+    "gender": "女性",
+    "residence": {
+      "prefecture": "京都府"
+    },
+    "occupationCategory": "教育"
   },
   {
     "id": "morita-ai",
@@ -96,7 +227,18 @@
     "occupation": "パート / 主婦",
     "description": "広島在住の主婦。2人の娘は独立。スーパーでパートしながら、韓ドラとヨガを楽しむ日々。",
     "image": "/images/personas/morita-ai.png",
-    "tags": ["主婦", "女性", "パート", "50代", "広島"]
+    "tags": [
+      "主婦",
+      "女性",
+      "パート",
+      "50代",
+      "広島"
+    ],
+    "gender": "女性",
+    "residence": {
+      "prefecture": "広島県"
+    },
+    "occupationCategory": "家庭"
   },
   {
     "id": "kuroda-maria",
@@ -105,7 +247,23 @@
     "occupation": "外資系コンサルタント",
     "description": "仙台出身、港区在住のエリートコンサル。MBA持ち。激務の中でもワークアウトは欠かさない。",
     "image": "/images/personas/kuroda-maria.png",
-    "tags": ["コンサル", "女性", "エリート", "30代", "東京"]
+    "tags": [
+      "コンサル",
+      "女性",
+      "エリート",
+      "30代",
+      "東京"
+    ],
+    "gender": "女性",
+    "birthplace": {
+      "prefecture": "宮城県",
+      "city": "仙台"
+    },
+    "residence": {
+      "prefecture": "東京都",
+      "city": "港区"
+    },
+    "occupationCategory": "コンサル"
   },
   {
     "id": "aoki-yuri",
@@ -114,7 +272,21 @@
     "occupation": "看護師",
     "description": "鹿児島出身、福岡在住。大学病院の救急外来勤務。彼氏と同棲中で、患者さんの明日を守る。",
     "image": "/images/personas/aoki-yuri.png",
-    "tags": ["看護師", "女性", "医療", "20代", "福岡"]
+    "tags": [
+      "看護師",
+      "女性",
+      "医療",
+      "20代",
+      "福岡"
+    ],
+    "gender": "女性",
+    "birthplace": {
+      "prefecture": "鹿児島県"
+    },
+    "residence": {
+      "prefecture": "福岡県"
+    },
+    "occupationCategory": "医療"
   },
   {
     "id": "hashimoto-nana",
@@ -123,7 +295,17 @@
     "occupation": "フリーター / ダンサー志望",
     "description": "岡山から上京したダンサー志望。複数バイトで生活しながら、プロを目指して奮闘中。",
     "image": "/images/personas/hashimoto-nana.png",
-    "tags": ["ダンサー", "女性", "フリーター", "20代", "東京"]
+    "tags": [
+      "ダンサー",
+      "女性",
+      "フリーター",
+      "20代",
+      "東京"
+    ],
+    "gender": "女性",
+    "residence": {
+      "prefecture": "複数バイト"
+    }
   },
   {
     "id": "nishimura-sakura",
@@ -132,7 +314,15 @@
     "occupation": "ヨガインストラクター / カフェオーナー",
     "description": "東京から長野へ移住。夫と息子と暮らしながら、古民家カフェとヨガスタジオを経営。スローライフ実践中。",
     "image": "/images/personas/nishimura-sakura.png",
-    "tags": ["ヨガ", "女性", "カフェ", "30代", "長野"]
+    "tags": [
+      "ヨガ",
+      "女性",
+      "カフェ",
+      "30代",
+      "長野"
+    ],
+    "gender": "女性",
+    "occupationCategory": "経営"
   },
   {
     "id": "ohno-rei",
@@ -141,7 +331,15 @@
     "occupation": "ゲストハウス経営 / ダイビングインストラクター",
     "description": "横浜から沖縄へ移住したシングルマザー。娘と二人暮らし。海を愛し、自由に生きる。",
     "image": "/images/personas/ohno-rei.png",
-    "tags": ["経営者", "女性", "シングルマザー", "40代", "沖縄"]
+    "tags": [
+      "経営者",
+      "女性",
+      "シングルマザー",
+      "40代",
+      "沖縄"
+    ],
+    "gender": "女性",
+    "occupationCategory": "経営"
   },
   {
     "id": "yoshida-emi",
@@ -150,7 +348,19 @@
     "occupation": "地方公務員（市役所福祉課）",
     "description": "仙台在住の公務員。東日本大震災を経験し、福祉の道へ。実家で祖母の介護をしながら、婚活中。",
     "image": "/images/personas/yoshida-emi.png",
-    "tags": ["公務員", "女性", "福祉", "20代", "仙台"]
+    "tags": [
+      "公務員",
+      "女性",
+      "福祉",
+      "20代",
+      "仙台"
+    ],
+    "gender": "女性",
+    "residence": {
+      "prefecture": "宮城県",
+      "city": "仙台"
+    },
+    "occupationCategory": "公務"
   },
   {
     "id": "murakami-ayaka",
@@ -159,7 +369,15 @@
     "occupation": "和菓子店女将 / 茶道教室主宰",
     "description": "札幌の老舗和菓子店3代目女将。夫と2人の子供の母。茶道教室を開き、日本文化の継承に努める。",
     "image": "/images/personas/murakami-ayaka.png",
-    "tags": ["経営者", "女性", "伝統", "40代", "札幌"]
+    "tags": [
+      "経営者",
+      "女性",
+      "伝統",
+      "40代",
+      "札幌"
+    ],
+    "gender": "女性",
+    "occupationCategory": "経営"
   },
   {
     "id": "hayashi-mio",
@@ -168,6 +386,19 @@
     "occupation": "声優志望 / アニメイトスタッフ",
     "description": "和歌山出身、大阪在住の声優志望。アニメイトで働きながらオーディションに挑戦。推し活に人生を捧げる。",
     "image": "/images/personas/hayashi-mio.png",
-    "tags": ["声優志望", "女性", "オタク", "20代", "大阪"]
+    "tags": [
+      "声優志望",
+      "女性",
+      "オタク",
+      "20代",
+      "大阪"
+    ],
+    "gender": "女性",
+    "birthplace": {
+      "prefecture": "和歌山県"
+    },
+    "residence": {
+      "prefecture": "大阪府"
+    }
   }
 ]

--- a/scripts/migrate-personas.js
+++ b/scripts/migrate-personas.js
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+const src = path.join(process.cwd(), 'samples', 'personas-list.json');
+const raw = JSON.parse(fs.readFileSync(src, 'utf8'));
+
+function inferGender(tags = []) {
+  if (tags.includes('女性')) return '女性';
+  if (tags.includes('男性')) return '男性';
+  return undefined;
+}
+
+function capture(regex, text) {
+  const m = text.match(regex);
+  return m ? m[1] : undefined;
+}
+
+function inferBirthplace(desc) {
+  // 例: 「静岡出身」「大阪出身の」など
+  const place = capture(/([一-龥ぁ-んァ-ンA-Za-z0-9々ー]+)出身/u, desc || '');
+  if (!place) return undefined;
+  const norm = normalizeLocToken(place);
+  return norm ? { prefecture: norm.prefecture, city: norm.city } : undefined;
+}
+
+function inferResidence(desc) {
+  // 例: 「東京在住」「渋谷区在住」
+  let place = capture(/([一-龥ぁ-んァ-ンA-Za-z0-9々ー]+)在住/u, desc || '');
+  if (!place) {
+    // 控えめに「〜で暮らす」のみ対応（"生活" は無視）
+    place = capture(/([一-龥ぁ-んァ-ンA-Za-z0-9々ー]+)で暮らす/u, desc || '');
+  }
+  if (!place) return undefined;
+  const norm = normalizeLocToken(place);
+  return norm ? { prefecture: norm.prefecture, city: norm.city } : undefined;
+}
+
+function inferOccupationCategory(occupation = '') {
+  const o = occupation.toLowerCase();
+  if (/it|エンジニア|web|pm|プロダクト/.test(o)) return 'IT';
+  if (/デザイナ/.test(o)) return 'デザイン';
+  if (/教師|教諭|教授|大学|学校/.test(o)) return '教育';
+  if (/看護|医療|病院/.test(o)) return '医療';
+  if (/営業/.test(o)) return '営業';
+  if (/公務員/.test(o)) return '公務';
+  if (/コンサル/.test(o)) return 'コンサル';
+  if (/経営|オーナー|女将|店/.test(o)) return '経営';
+  if (/主婦|パート/.test(o)) return '家庭';
+  if (/学生/.test(o)) return '学生';
+  return undefined;
+}
+
+// Prefecture canonical names
+const PREF_MAP = new Map([
+  ['北海道', '北海道'],
+  ['青森', '青森県'], ['岩手', '岩手県'], ['宮城', '宮城県'], ['秋田', '秋田県'], ['山形', '山形県'], ['福島', '福島県'],
+  ['茨城', '茨城県'], ['栃木', '栃木県'], ['群馬', '群馬県'], ['埼玉', '埼玉県'], ['千葉', '千葉県'], ['東京', '東京都'], ['東京都', '東京都'], ['神奈川', '神奈川県'],
+  ['新潟', '新潟県'], ['富山', '富山県'], ['石川', '石川県'], ['福井', '福井県'], ['山梨', '山梨県'], ['長野', '長野県'],
+  ['岐阜', '岐阜県'], ['静岡', '静岡県'], ['愛知', '愛知県'],
+  ['三重', '三重県'], ['滋賀', '滋賀県'], ['京都', '京都府'], ['京都府', '京都府'], ['大阪', '大阪府'], ['大阪府', '大阪府'], ['兵庫', '兵庫県'], ['奈良', '奈良県'], ['和歌山', '和歌山県'],
+  ['鳥取', '鳥取県'], ['島根', '島根県'], ['岡山', '岡山県'], ['広島', '広島県'], ['山口', '山口県'],
+  ['徳島', '徳島県'], ['香川', '香川県'], ['愛媛', '愛媛県'], ['高知', '高知県'],
+  ['福岡', '福岡県'], ['佐賀', '佐賀県'], ['長崎', '長崎県'], ['熊本', '熊本県'], ['大分', '大分県'], ['宮崎', '宮崎県'], ['鹿児島', '鹿児島県'], ['沖縄', '沖縄県']
+]);
+
+const CITY_TO_PREF = new Map([
+  ['横浜', '神奈川県'],
+  ['鎌倉', '神奈川県'],
+  ['渋谷区', '東京都'],
+  ['港区', '東京都'],
+  ['名古屋', '愛知県'],
+  ['神戸', '兵庫県'],
+  ['札幌', '北海道'],
+  ['仙台', '宮城県'],
+  // 同名が都道府県の場合は都道府県を優先
+  ['京都', '京都府'],
+  ['大阪', '大阪府'],
+  ['東京', '東京都'],
+]);
+
+function normalizeLocToken(token) {
+  if (!token) return undefined;
+  const t = String(token).replace(/県|府|都|道/g, '');
+  // prefecture canonical
+  const pref = PREF_MAP.get(t) || PREF_MAP.get(token) || CITY_TO_PREF.get(token);
+  if (pref) {
+    // If it's a city mapping (CITY_TO_PREF) and not pure prefecture string, keep city
+    const isCity = CITY_TO_PREF.has(token) && !PREF_MAP.has(t) && !PREF_MAP.has(token);
+    return { prefecture: pref, city: isCity ? token : undefined };
+  }
+  // Fallback: if token ends with 区/市/町/村 treat as city, try rough mapping for big cities
+  if (/区|市|町|村$/.test(token)) {
+    const pref2 = CITY_TO_PREF.get(token) || undefined;
+    return { prefecture: pref2, city: token };
+  }
+  return undefined;
+}
+
+const migrated = raw.map((p) => {
+  const next = { ...p };
+  if (!next.gender) next.gender = inferGender(next.tags);
+  if (!next.birthplace) next.birthplace = inferBirthplace(next.description);
+  if (!next.residence) next.residence = inferResidence(next.description);
+  // Normalize birthplace/residence to prefecture base, keep city detail when available
+  if (next.birthplace?.prefecture) {
+    const norm = normalizeLocToken(next.birthplace.prefecture);
+    if (norm) next.birthplace = { prefecture: norm.prefecture, city: norm.city || next.birthplace.city };
+  }
+  if (next.residence?.prefecture) {
+    const norm = normalizeLocToken(next.residence.prefecture);
+    if (norm) next.residence = { prefecture: norm.prefecture, city: norm.city || next.residence.city };
+  }
+  if (!next.occupationCategory) next.occupationCategory = inferOccupationCategory(next.occupation || '');
+  // 性格(personality)は未運用のため削除しておく（誤混入防止）
+  if (next.personality) delete next.personality;
+  return next;
+});
+
+fs.writeFileSync(src, JSON.stringify(migrated, null, 2) + '\n', 'utf8');
+console.log(`Migrated ${migrated.length} personas -> samples/personas-list.json`);

--- a/types/persona.ts
+++ b/types/persona.ts
@@ -1,0 +1,43 @@
+export type Gender = '女性' | '男性' | 'その他';
+
+export interface LocationInfo {
+  prefecture?: string;
+  city?: string;
+}
+
+export interface Persona {
+  id: string;
+  name: string;
+  age: number;
+  gender?: Gender;
+  occupation: string;
+  occupationCategory?: string;
+  description: string;
+  image: string;
+  tags: string[];
+  personality?: string[]; // 性格・特徴
+  birthplace?: LocationInfo; // 出身地
+  residence?: LocationInfo; // 在住地
+}
+
+// 旧スキーマからのフォールバック補助
+export function matchesGender(p: Persona, wanted: Gender): boolean {
+  if (!wanted) return true;
+  if (p.gender) return p.gender === wanted;
+  // fallback: tags に含まれていれば採用
+  return (p.tags || []).includes(wanted);
+}
+
+export function containsText(hay: string | undefined, needle: string): boolean {
+  return (hay || '').toLowerCase().includes(needle.toLowerCase());
+}
+
+export function locationMatches(loc: LocationInfo | undefined, q: string): boolean {
+  if (!q) return true;
+  const n = q.toLowerCase();
+  return (
+    containsText(loc?.prefecture, n) ||
+    containsText(loc?.city, n)
+  );
+}
+


### PR DESCRIPTION
目的
- ユーザーインタビュー用コンテキストの検索性向上とデータ表現の一貫性向上

主な変更
- コレクション検索UI/仕様
  - フィルターを選択式に統一：性別／年齢（最小・最大）／職業カテゴリ／職業（詳細）／出身地（都道府県）／在住地（都道府県）／キーワード
  - 入力と同時に自動検索＆URLクエリへ同期（リロードで条件保持）
  - 検索ボタン廃止、クリアで条件とクエリを初期化
- データスキーマ/移行
  - 都道府県名を正規化し統一（東京都/大阪府/京都府/北海道…）
  - 詳細は city に保持（例：渋谷区、港区、横浜、名古屋、鎌倉、神戸、札幌、仙台 など）
  - `scripts/migrate-personas.js` を追加し自動変換（実行済み）
  - 型定義 `types/persona.ts` を追加し、後方互換ユーティリティも提供
- UI/ナビ
  - ホームに共通ヘッダー、ティーザー（3件）、作成導線、フッターを追加/調整
  - コレクションは該当件数表示、条件はクエリ同期
- ドキュメント
  - `AGENTS.md` 追加（PRは日本語で作成する旨を明記）

影響範囲
- 追加/更新ファイル
  - `components/samples/PersonaList.tsx`（検索UI/ロジック）
  - `pages/index.tsx`（トップの導線/フッター/ティーザー）
  - `pages/samples/index.tsx`（型利用）
  - `pages/samples/personas/[id].tsx`, `[id]/prompt.tsx`（型利用や導線）
  - `samples/personas-list.json`（都道府県正規化＋city）
  - `scripts/migrate-personas.js`（移行）
  - `types/persona.ts`（型）
  - `AGENTS.md`

テスト/確認
- `npm run build` 成功（Nextの <img> 最適化警告のみ）
- `/samples` にてフィルター変更→即時検索＆URL反映
- クエリ付きでアクセス→状態復元、リロード後も条件維持
- 出身地/在住地は都道府県で一致、cityは保持のみ

補足
- 性格・特徴の選択はデータ正規化が未整備のため今回は未実装
- 職業カテゴリは推論を行っています。必要に応じて固定辞書化可能です。