### PR TITLE
検索結果の件数を表示（フィルター直下に追加）

### DIFF
--- a/components/samples/PersonaList.tsx
+++ b/components/samples/PersonaList.tsx
@@ -334,7 +334,10 @@ const PersonaList: React.FC<PersonaListProps> = ({ personas }) => {
             </div>
             {/* 性格・特徴の選択は未整備のため一旦未実装 */}
             <div className="flex gap-2 md:col-span-2 lg:col-span-4 justify-between items-center">
-              <span className="text-xs text-gray-500">条件は変更と同時に適用されます</span>
+              <div className="flex items-center gap-3 text-sm">
+                <span className="inline-flex items-center px-2 py-1 rounded-md bg-gray-100 text-gray-700">該当 {filtered.length} 件</span>
+                <span className="text-xs text-gray-500">条件は変更と同時に適用されます</span>
+              </div>
               <button className="btn-secondary h-10 px-3" onClick={resetFilters}>クリア</button>
             </div>
           </div>


### PR DESCRIPTION
概要
- コレクションの検索UIに「該当 件数」バッジを常時表示しました。
- 条件を変更すると即時に件数が更新され、結果の規模が一目で分かります。

変更点
- components/samples/PersonaList.tsx
  - フィルターエリア下部に「該当 {filtered.length} 件」を追加
  - 既存の見出し側の件数表示（該当 N 件のコンテキスト）と併せて、より把握しやすくしました

動作確認
- 条件変更時に件数が即時更新されること
- クリア時に全件へ戻ること

補足
- UI上の配置や文言（例: バッジの色/サイズ、表記揺れ）に希望があれば調整します。